### PR TITLE
Minor changes to improve usability and robustness

### DIFF
--- a/Commands/Get Gist.tmCommand
+++ b/Commands/Get Gist.tmCommand
@@ -18,7 +18,7 @@ Gistmate.new().get(ENV['TM_SELECTED_TEXT'])
 	<key>keyEquivalent</key>
 	<string>^@g</string>
 	<key>name</key>
-	<string>Get Gist</string>
+	<string>Get Gist…</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>

--- a/Commands/Get My Gist.tmCommand
+++ b/Commands/Get My Gist.tmCommand
@@ -18,7 +18,7 @@ Gistmate.new().pick()
 	<key>keyEquivalent</key>
 	<string>^@g</string>
 	<key>name</key>
-	<string>Pick My Gists</string>
+	<string>Pick My Gists…</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>

--- a/README.markdown
+++ b/README.markdown
@@ -24,17 +24,18 @@ Some limitations to be aware of:
 * Although you can download multi-file gists, the create and update processes only work with the current file.
 
 ## The Cache
-	
+
 This plugin caches the mapping between file names and gist id's in the file `~/.gists`. This cache is shared with my [cached gist command](https://github.com/hiltmon/gist) for command line use. The bundle uses this cache to enable updates to gists without the user having to remember gist id's (and because TextMate does not have any way to add custom attributes to open files).
 
 ## Installation
 
+You can find this bundle in TextMate → Preferences → Bundles → Gist where it can be enabled.
+
 To install via Git:
 
-    mkdir -p ~/Library/Application\ Support/TextMate/Bundles
-    cd ~/Library/Application\ Support/TextMate/Bundles
-    git clone git://github.com/hiltmon/Gist.tmbundle.git "Gist.tmbundle"
-    osascript -e 'tell app "TextMate" to reload bundles'
+    mkdir -p ~/Library/Application\ Support/Avian/Bundles
+    cd ~/Library/Application\ Support/Avian/Bundles
+    git clone git://github.com/hiltmon/Gist.tmbundle
 
 ## Authentication
 

--- a/Support/bin/gistmate.rb
+++ b/Support/bin/gistmate.rb
@@ -234,7 +234,7 @@ class Gistmate
     unless files_array.nil?
       # Open em
       files_array.each do |file_name|
-        %x{mate "#{file_name}"}
+        %x{"$TM_SUPPORT_PATH/bin/mate" "#{file_name}"}
       end
     end
   end

--- a/Support/bin/gistmate.rb
+++ b/Support/bin/gistmate.rb
@@ -101,7 +101,7 @@ class Gistmate
     filename = File.basename(path)
     text = url_gist(filename)
     TextMate.exit_show_html(no_gist_message) if text.nil?
-    %x{open #{text}}
+    %x{open #{e_sh text}}
   end
   
   def update(path)
@@ -234,7 +234,7 @@ class Gistmate
     unless files_array.nil?
       # Open em
       files_array.each do |file_name|
-        %x{"$TM_SUPPORT_PATH/bin/mate" "#{file_name}"}
+        %x{"$TM_SUPPORT_PATH/bin/mate" #{e_sh file_name}}
       end
     end
   end

--- a/Support/bin/gistmate.rb
+++ b/Support/bin/gistmate.rb
@@ -42,7 +42,7 @@ require 'fileutils'
 require "#{ENV['TM_SUPPORT_PATH']}/lib/exit_codes.rb"
 require "#{ENV['TM_SUPPORT_PATH']}/lib/escape.rb"
 require "#{ENV['TM_SUPPORT_PATH']}/lib/ui.rb"
-require ENV['TM_SUPPORT_PATH'] + '/lib/tm/htmloutput'
+require "#{ENV['TM_SUPPORT_PATH']}/lib/osx/plist"
 
 class Gistmate
   
@@ -73,7 +73,7 @@ class Gistmate
   end
   
   def pick()
-    TextMate.exit_show_html(no_auth_message) if no_auth?
+    abort_no_auth if no_auth?
     user, _ = auth()
     results = list_gists(user)
     
@@ -93,23 +93,23 @@ class Gistmate
   def url(path)
     filename = File.basename(path)
     text = url_gist(filename)
-    TextMate.exit_show_html(no_gist_message) if text.nil?
+    abort_no_gist if text.nil?
     TextMate.exit_show_tool_tip("'#{text}' Copied to Clipboard.") unless text.nil?
   end
   
   def view_on_web(path)
     filename = File.basename(path)
     text = url_gist(filename)
-    TextMate.exit_show_html(no_gist_message) if text.nil?
+    abort_no_gist if text.nil?
     %x{open #{e_sh text}}
   end
   
   def update(path)
-    TextMate.exit_show_html(no_auth_message) if no_auth?
+    abort_no_auth if no_auth?
     filename = File.basename(path)
     
     gist_id = get_id_from_cache(filename)
-    TextMate.exit_show_html(no_gist_message) if gist_id.nil?
+    abort_no_gist if gist_id.nil?
 
     response = api_post_request([path], gist_id)
     unless response.nil?
@@ -119,11 +119,11 @@ class Gistmate
   end
   
   def create(path, is_private)
-    TextMate.exit_show_html(no_auth_message) if no_auth?
+    abort_no_auth if no_auth?
     filename = File.basename(path)
     
     gist_id = get_id_from_cache(filename)
-    TextMate.exit_show_html(is_gist_message) unless gist_id.nil?
+    abort_gist_already_exist unless gist_id.nil?
     
     gist_id = create_gist(filename, is_private)
     unless gist_id.nil?
@@ -186,47 +186,21 @@ class Gistmate
     nil
   end
   
-  def no_auth_message
-    TextMate::HTMLOutput.show(
-      :title      => "GitHub Authentication Error"
-    ) do |io|
-      io << <<-HTML
-        <h3 class="error">GitHub Authentication is not set up.</h3>
-
-        <p>The gists bundle needs your github user name and password to compleet this action.</p>
-
-        <p>Either add github.user and github.password to your global git config, or set the
-          GITHUB_USER and GITHUB_PASSWORD environment variables.</p>
-      HTML
-    end
+  def abort_no_auth
+    %x{ "$DIALOG" >/dev/null alert --title "GitHub authentication error." --body "To setup authentication you should run the following in a terminal:\n\ngit config --global github.user «username»\ngit config --global github.password «password»" --button1 OK }
+    TextMate.exit_discard
   end
   
-  def no_gist_message
-    TextMate::HTMLOutput.show(
-      :title      => "Gist Error"
-    ) do |io|
-      io << <<-HTML
-        <h3 class="error">Unknown Gist.</h3>
-
-        <p>This file is not part of a known gist. Either <strong>Create Gist</strong> to
-          create a new gist, or <strong>Get Gist</strong> to retrieve a gist before
-          editing. <strong>Warning:</strong> Get Gist will overwrite this file.</p>
-      HTML
-    end
+  def abort_no_gist
+    %x{ "$DIALOG" >/dev/null alert --title "No known gist for “${TM_DISPLAYNAME}”." --body "Either use “Create Gist” to register “${TM_DISPLAYNAME}” as a new gist, or use “Get Gist…” to retrieve an existing gist." --button1 OK }
+    TextMate.exit_discard
   end
 
-  def is_gist_message
-    TextMate::HTMLOutput.show(
-      :title      => "Gist Error"
-    ) do |io|
-      io << <<-HTML
-        <h3 class="error">Gist already Created!</h3>
-
-        <p>This file is part of a known gist. Either <strong>Update Gist</strong> to
-          update it, or remove this gist from the cache and try again. The cache can
-          be found in <code>~/.gists</code></p>
-      HTML
-    end
+  def abort_gist_already_exist
+    plist = %x{ "$DIALOG" alert --title "A gist already exist for “${TM_DISPLAYNAME}”." --body "You can use “Update Gist” to update the online version.\n\nIf you want to force create a new gist for this document then you must first remove the existing one from the cache." --button1 OK --button2 "Edit Cache" }
+    hash = OSX::PropertyList::load(plist)
+    %x{"$TM_SUPPORT_PATH/bin/mate" -tsource.yaml #{e_sh CACHE_FILE_PATH}} if hash['buttonClicked'].to_i == 1
+    TextMate.exit_discard
   end
   
   def textmate_get_gist(gist_id)

--- a/TODO.markdown
+++ b/TODO.markdown
@@ -6,3 +6,9 @@
 - Add file to Gist
 - Delete Gist
 - Modify Gist Description
+
+## Suggestions
+
+- Use `TM_DOCUMENT_UUID` as primary cache key and fallback on `TM_FILEPATH`. This should allow dealing with unsaved documents without needing to actually save them.
+- Fetching a gist should pipe the data to `mate` so that we get an unsaved document. File type and display name can be set via options, but presently there is no `--uuid`, which would be required to allow later updating the fetched gist (this should be added to mate).
+- Wrap network IO in `TextMate.call_with_progress` (from `#{ENV['TM_SUPPORT_PATH']}/lib/progress`).


### PR DESCRIPTION
I made a few minor changes, hope you like.

I also added some suggestions to the TODO list — I can add the `--uuid` option to `mate` if you think the cache can be made to use the document UUID as key — I am not yet familiar enough with the bundle, gist API, and desired workflow, to say how to best match online and offline documents, but I think the current scheme can be improved.
